### PR TITLE
feat: add Counter Strike 2 server

### DIFF
--- a/pkg/gameServers/gameServerService.go
+++ b/pkg/gameServers/gameServerService.go
@@ -30,6 +30,11 @@ var serverLookups = [...]ServerLookup{
 		Host: "disqt.com",
 		Port: "26420",
 	},
+	{
+		Id:   "csgo",
+		Host: "disqt.com",
+		Port: "27015",
+	},
 }
 
 // GetGameServers Run command, if error then add an OfflineServer to response

--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -38,7 +38,11 @@ func NewOnlineGameServer(name string, host string, port string, players int, max
 		redirect = "https://stats.xonotic.org/server/46827"
 	}
 
-	name = strings.ToUpper(string(name[0])) + name[1:]
+	if strings.ToLower(name) == "csgo" {
+		name = "Counter Strike 2"
+	} else {
+		name = strings.ToUpper(string(name[0])) + name[1:]
+	}
 
 	return OnlineGameServer{
 		IsOnline:   true,
@@ -85,7 +89,11 @@ type OfflineGameServer struct {
 }
 
 func NewOfflineGameServer(name string) OfflineGameServer {
-	name = strings.ToUpper(string(name[0])) + name[1:]
+	if strings.ToLower(name) == "csgo" {
+		name = "Counter Strike 2"
+	} else {
+		name = strings.ToUpper(string(name[0])) + name[1:]
+	}
 	return OfflineGameServer{
 		Name:     name,
 		IsOnline: false,


### PR DESCRIPTION
## Summary
- Add CS2 server to the API (gamedig type `csgo` on port 27015)
- Map gamedig type `csgo` to display name "Counter Strike 2"

## Changes
- `gameServerService.go`: Added CS2 to serverLookups array
- `gameServer.go`: Added name mapping for csgo → "Counter Strike 2" in both online and offline server constructors

## Test plan
- [x] Verified on production server: API returns `"Counter Strike 2": { "Running": true, ... }`

---
Generated with [Claude Code](https://claude.ai/claude-code)