### PR TITLE
feat: add steam:// connect link for CS2

### DIFF
--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -40,6 +40,7 @@ func NewOnlineGameServer(name string, host string, port string, players int, max
 
 	if strings.ToLower(name) == "csgo" {
 		name = "Counter Strike 2"
+		redirect = "steam://connect/" + host + ":" + port
 	} else {
 		name = strings.ToUpper(string(name[0])) + name[1:]
 	}


### PR DESCRIPTION
## Summary
Clicking "Counter Strike 2" on the website will now open Steam and connect directly to the server.

## How it works
The API now returns a `Redirect` URL for CS2:
```
steam://connect/disqt.com:27015
```

This uses Steam's protocol handler to launch the game and connect.

## Test plan
- [ ] Click "Counter Strike 2" on https://disqt.com
- [ ] Steam should prompt to open
- [ ] Game should launch and connect to server

---
Generated with [Claude Code](https://claude.ai/claude-code)