### PR TITLE
Fix steam://connect URL missing port number

### DIFF
--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -40,7 +40,7 @@ func NewOnlineGameServer(name string, host string, port string, players int, max
 
 	if strings.ToLower(name) == "csgo" {
 		name = "Counter Strike 2"
-		redirect = "steam://connect/" + host
+		redirect = "steam://connect/" + host + ":27015"
 		port = ""
 	} else {
 		name = strings.ToUpper(string(name[0])) + name[1:]


### PR DESCRIPTION
## Summary
- Fixed the Steam connect URL for CS2 to include the port number

## Problem
The `steam://connect/disqt.com` URL was missing the port, causing Steam to fail silently when clicking the connect button on the website.

Steam's connect protocol requires the format `steam://connect/host:port` - it queries the server on that port to determine which game to launch. Without the port, Steam has nowhere to send the query.

## Fix
Changed the redirect URL from:
```
steam://connect/disqt.com
```
to:
```
steam://connect/disqt.com:27015
```

## Test plan
- [ ] Deploy to VPS
- [ ] Click the Steam connect button on disqt.com
- [ ] Verify CS2 launches and connects to the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)