### PR TITLE
Use rungameid format for Steam connect URL

### DIFF
--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -40,7 +40,7 @@ func NewOnlineGameServer(name string, host string, port string, players int, max
 
 	if strings.ToLower(name) == "csgo" {
 		name = "Counter Strike 2"
-		redirect = "steam://connect/" + host + ":27015"
+		redirect = "steam://rungameid/730//+connect " + host + ":27015"
 		port = ""
 	} else {
 		name = strings.ToUpper(string(name[0])) + name[1:]


### PR DESCRIPTION
## Summary
- Changed Steam connect URL format from `steam://connect/` to `steam://rungameid/730//+connect`

## Problem
The `steam://connect/hostname:port` protocol has a known Steam client bug where DNS resolution fails silently - hostnames don't work but IP addresses do. This bug has been reported since 2017 and remains unfixed.

## Solution
Using `steam://rungameid/730//+connect hostname:port` bypasses this issue and correctly resolves hostnames.

## Test plan
- [x] Tested `steam://connect/disqt.com:27015` - fails silently
- [x] Tested `steam://connect/195.201.114.132:27015` - works (IP only)
- [x] Tested `steam://rungameid/730//+connect disqt.com:27015` - works with hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)