### PR TITLE
Fix player count to exclude bots

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -27,10 +27,10 @@ func TestGetServersHandler(t *testing.T) {
 	t.Run("Minecraft On, Valheim Off, Xonotic On, CS2 On", func(t *testing.T) {
 		gameDigClientMock := new(MockedGameDigClient)
 
-		gameDigClientMock.On("GetServerInfo", "minecraft", "disqt.com", "").Return([]byte(`{"maxplayers":420,"numplayers":0,"queryPort": 25565}`), nil)
+		gameDigClientMock.On("GetServerInfo", "minecraft", "disqt.com", "").Return([]byte(`{"maxplayers":420,"numplayers":0,"queryPort": 25565,"players":[]}`), nil)
 		gameDigClientMock.On("GetServerInfo", "valheim", "disqt.com", "").Return([]byte(`{"error":"Failed all 1 attempts"}`), nil)
-		gameDigClientMock.On("GetServerInfo", "xonotic", "disqt.com", "26420").Return([]byte(`{"maxplayers":"420","numplayers":0,"queryPort": 26420}`), nil)
-		gameDigClientMock.On("GetServerInfo", "csgo", "disqt.com", "27015").Return([]byte(`{"maxplayers":10,"numplayers":3,"queryPort": 27015}`), nil)
+		gameDigClientMock.On("GetServerInfo", "xonotic", "disqt.com", "26420").Return([]byte(`{"maxplayers":"420","numplayers":0,"queryPort": 26420,"players":[]}`), nil)
+		gameDigClientMock.On("GetServerInfo", "csgo", "disqt.com", "27015").Return([]byte(`{"maxplayers":10,"numplayers":13,"queryPort": 27015,"players":[{"name":"Player1"},{"name":"Player2"},{"name":"Player3"}],"bots":[{"name":"Bot1"},{"name":"Bot2"},{"name":"Bot3"},{"name":"Bot4"},{"name":"Bot5"},{"name":"Bot6"},{"name":"Bot7"},{"name":"Bot8"},{"name":"Bot9"},{"name":"Bot10"}]}`), nil)
 
 		gameDigClient := client.GameDigClient{
 			GetServerInfo: gameDigClientMock.GetServerInfo,

--- a/pkg/gameServers/gameServerService.go
+++ b/pkg/gameServers/gameServerService.go
@@ -58,17 +58,13 @@ func GetGameServers(gameDigClient client.GameDigClient) ([]model.GameServer, err
 					return
 				}
 
-				currentPlayer, err := response.Players.Int64()
-				if err != nil {
-					log.Println("Error getting current player")
-					currentPlayer = 0
-				}
+				currentPlayer := len(response.Players)
 				maxPlayers, err := response.MaxPlayers.Int64()
 				if err != nil {
 					log.Println("Error getting max players")
 					maxPlayers = 0
 				}
-				results[i] = result{server: model.NewOnlineGameServer(lookup.Id, lookup.Host, string(response.Port), int(currentPlayer), int(maxPlayers))}
+				results[i] = result{server: model.NewOnlineGameServer(lookup.Id, lookup.Host, string(response.Port), currentPlayer, int(maxPlayers))}
 			}
 		}(i, lookup)
 	}

--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -7,9 +7,10 @@ import (
 
 type GameDigResponse struct {
 	Game       string
-	Players    json.Number `json:"numplayers"`
-	MaxPlayers json.Number `json:"maxplayers"`
-	Port       json.Number `json:"queryPort"`
+	NumPlayers json.Number       `json:"numplayers"`
+	MaxPlayers json.Number       `json:"maxplayers"`
+	Port       json.Number       `json:"queryPort"`
+	Players    []json.RawMessage `json:"players"`
 }
 
 type GameServer interface {


### PR DESCRIPTION
## Summary
- GameDig's `numplayers` field includes bots in the count, causing the CS2 server to show 10/10 players when only bots are connected
- Changed to use `len(players)` array (human players only) instead of `numplayers`
- Updated test mocks to include `players` array with realistic bot/player split

## Test plan
- [x] `go test ./...` passes on VPS
- [ ] After deploy: verify `GET /servers` returns `"Players": 0` when only bots are on CS2
- [ ] Rebuild binary and restart `lgsm-info-api.service`