### PR TITLE
feat: add Windrose to /servers response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,31 +32,35 @@ sudo systemctl restart lgsm-info-api.service
 
 ## Architecture
 
-This is a Go/Gin HTTP API that queries game server status using the external `gamedig` CLI tool.
+This is a Go/Gin HTTP API that queries game server status using the external `gamedig` CLI tool, plus a direct file read for Windrose (which gamedig does not support).
 
 **Request flow:**
 1. `GET /servers` hits `GameServersHandler` in `cmd/main.go`
 2. Handler calls `gameServers.GetGameServers()` which iterates over hardcoded `serverLookups`
 3. For each server, `GameDigClient` executes `gamedig --type <game> <host> [--port <port>]`
-4. Response is parsed and transformed into `OnlineGameServer` or `OfflineGameServer`
-5. `model.NewResponse()` in `cmd/model/response.go` builds the final JSON response
+4. Separately, `GetWindroseServer()` reads the local WindrosePlus `server_status.json` file
+5. Responses are parsed and transformed into `OnlineGameServer` or `OfflineGameServer`
+6. `model.NewResponse()` in `cmd/model/response.go` builds the final JSON response
 
 **Key files:**
 - `pkg/gameServers/gameServerService.go` - Server lookup definitions and query orchestration
 - `pkg/gameServers/model/gameServer.go` - Game server domain models with Steam/redirect URL generation
 - `pkg/gameServers/client/gameDigClient.go` - GameDig CLI wrapper (injectable for testing)
+- `pkg/gameServers/client/windroseClient.go` - WindrosePlus status-file reader (injectable for testing)
 - `cmd/model/response.go` - API response transformation
 
-**External dependency:** Requires `gamedig` CLI installed on the system (npm package `gamedig`).
+**External dependency:** Requires `gamedig` CLI installed on the system (npm package `gamedig`). For Windrose to appear online, the WindrosePlus status file at `/home/windrose/windrose/server-files/windrose_plus_data/server_status.json` must be readable by the API process and updated within 90s (matches the freshness gate used by `windrose-metrics.sh`).
 
 ## Server Configuration
 
-Server definitions are hardcoded in `pkg/gameServers/gameServerService.go` as `serverLookups`. Each server has game ID, host, and optional port.
+Server definitions are hardcoded in `pkg/gameServers/gameServerService.go` as `serverLookups` (gamedig-queried) and `windroseLookup` (file-read). Each gamedig server has game ID, host, and optional port.
 
 Steam connect URLs for CS2 use the `steam://rungameid/730//+connect` format to work around Steam's hostname DNS resolution bug with the standard `steam://connect/` protocol.
+
+Windrose has no equivalent connect link (Unreal-based, not Steam Source) and no usable A2S responder, so it's queried by reading the WindrosePlus dashboard's local `server_status.json` file. The path and freshness gate are constants in `cmd/main.go`. The Windrose response intentionally has empty `Url` and `Redirect` — there's no joinable URL to copy and no one-click join scheme; players join via the in-game invite-code flow.
 
 ## Production Notes
 
 - **nginx caching:** The `/servers` endpoint is cached by nginx with a 10-minute TTL and `stale-while-revalidate`, so clients may receive slightly stale data while a fresh response is being fetched in the background.
 - **Sequential queries:** The API queries each game server sequentially via the `gamedig` CLI (see the `for` loop in `GetGameServers`), so total response time scales linearly with the number of servers in `serverLookups`.
-- **Server lookup order:** Servers are queried in this order: minecraft, valheim, xonotic, csgo (CS2). The valheim entry still exists in the lookup list, but the Valheim server is no longer running -- it will always appear as offline in the response.
+- **Server lookup order:** Servers are queried in this order: minecraft, valheim, xonotic, csgo (CS2), windrose. The valheim entry still exists in the lookup list, but the Valheim server is no longer running -- it will always appear as offline in the response. The final response is sorted by `Running` (online first) then alphabetically, so this order doesn't affect display ordering.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,9 +26,15 @@ func setupRouter(cache *gameServers.ServerCache) *gin.Engine {
 	return router
 }
 
+const (
+	windroseStatusPath = "/home/windrose/windrose/server-files/windrose_plus_data/server_status.json"
+	windroseMaxAge     = 90 * time.Second
+)
+
 func main() {
 	gameDigClient := client.NewGameDigClient()
-	cache := gameServers.NewServerCache(gameDigClient, 30*time.Second)
+	windroseClient := client.NewWindroseClient(windroseStatusPath, windroseMaxAge)
+	cache := gameServers.NewServerCache(gameDigClient, windroseClient, 30*time.Second)
 	cache.Start()
 
 	router := setupRouter(cache)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -8,9 +8,38 @@ import (
 	"lgsm-info-api/pkg/gameServers/client"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
+
+type fakeFileInfo struct {
+	os.FileInfo
+	mtime time.Time
+}
+
+func (f fakeFileInfo) ModTime() time.Time { return f.mtime }
+
+func freshWindroseClient(body []byte) client.WindroseClient {
+	now := time.Unix(2_000_000_000, 0)
+	return client.WindroseClient{
+		StatusPath: "/fake",
+		MaxAge:     90 * time.Second,
+		Stat:       func(string) (os.FileInfo, error) { return fakeFileInfo{mtime: now}, nil },
+		Read:       func(string) ([]byte, error) { return body, nil },
+		Now:        func() time.Time { return now },
+	}
+}
+
+func offlineWindroseClient() client.WindroseClient {
+	return client.WindroseClient{
+		StatusPath: "/fake",
+		MaxAge:     90 * time.Second,
+		Stat:       func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		Read:       func(string) ([]byte, error) { return nil, nil },
+		Now:        time.Now,
+	}
+}
 
 type MockedGameDigClient struct {
 	mock.Mock
@@ -36,7 +65,9 @@ func TestGetServersHandler(t *testing.T) {
 			GetServerInfo: gameDigClientMock.GetServerInfo,
 		}
 
-		cache := gameServers.NewServerCache(gameDigClient, 1*time.Hour)
+		windroseClient := freshWindroseClient([]byte(`{"server":{"name":"disqt.com","player_count":2,"max_players":10}}`))
+
+		cache := gameServers.NewServerCache(gameDigClient, windroseClient, 1*time.Hour)
 		cache.Start()
 
 		r := setupRouter(cache)
@@ -64,6 +95,14 @@ func TestGetServersHandler(t *testing.T) {
 				"Redirect": "https://disqt.com/minecraft",
 				"Motd": "DISQT Minecraft"
 			},
+			"Windrose": {
+				"Url": "",
+				"Running": true,
+				"Players": 2,
+				"MaxPlayers": 10,
+				"Redirect": "",
+				"Motd": "disqt.com"
+			},
 			"Xonotic": {
 				"Url": "disqt.com:26420",
 				"Running": true,
@@ -77,5 +116,26 @@ func TestGetServersHandler(t *testing.T) {
 			}
 		}`
 		assert.JSONEq(t, expectedBody, w.Body.String())
+	})
+
+	t.Run("Windrose offline when status file missing", func(t *testing.T) {
+		gameDigClientMock := new(MockedGameDigClient)
+		gameDigClientMock.On("GetServerInfo", "minecraft", "disqt.com", "").Return([]byte(`{"error":"x"}`), nil)
+		gameDigClientMock.On("GetServerInfo", "valheim", "disqt.com", "").Return([]byte(`{"error":"x"}`), nil)
+		gameDigClientMock.On("GetServerInfo", "xonotic", "disqt.com", "26420").Return([]byte(`{"error":"x"}`), nil)
+		gameDigClientMock.On("GetServerInfo", "csgo", "disqt.com", "27015").Return([]byte(`{"error":"x"}`), nil)
+
+		gameDigClient := client.GameDigClient{GetServerInfo: gameDigClientMock.GetServerInfo}
+		cache := gameServers.NewServerCache(gameDigClient, offlineWindroseClient(), 1*time.Hour)
+		cache.Start()
+
+		r := setupRouter(cache)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/servers", nil)
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"Windrose": {`)
+		assert.Contains(t, w.Body.String(), `"Running": false`)
 	})
 }

--- a/pkg/gameServers/cache.go
+++ b/pkg/gameServers/cache.go
@@ -9,16 +9,18 @@ import (
 )
 
 type ServerCache struct {
-	mu       sync.RWMutex
-	response model.OrderedServerMap
-	client   client.GameDigClient
-	interval time.Duration
+	mu             sync.RWMutex
+	response       model.OrderedServerMap
+	gameDigClient  client.GameDigClient
+	windroseClient client.WindroseClient
+	interval       time.Duration
 }
 
-func NewServerCache(gameDigClient client.GameDigClient, interval time.Duration) *ServerCache {
+func NewServerCache(gameDigClient client.GameDigClient, windroseClient client.WindroseClient, interval time.Duration) *ServerCache {
 	return &ServerCache{
-		client:   gameDigClient,
-		interval: interval,
+		gameDigClient:  gameDigClient,
+		windroseClient: windroseClient,
+		interval:       interval,
 	}
 }
 
@@ -29,11 +31,13 @@ func (c *ServerCache) Get() model.OrderedServerMap {
 }
 
 func (c *ServerCache) refresh() {
-	servers, err := GetGameServers(c.client)
+	servers, err := GetGameServers(c.gameDigClient)
 	if err != nil {
 		log.Printf("Cache refresh error: %s", err)
 		return
 	}
+
+	servers = append(servers, GetWindroseServer(c.windroseClient))
 
 	response, err := model.NewResponse(servers)
 	if err != nil {

--- a/pkg/gameServers/client/windroseClient.go
+++ b/pkg/gameServers/client/windroseClient.go
@@ -43,9 +43,8 @@ func NewWindroseClient(statusPath string, maxAge time.Duration) WindroseClient {
 	}
 }
 
-// GetStatus returns the parsed status when the file exists and is fresh.
-// A second return value of false means "treat as offline" — the caller does
-// not need to distinguish missing / stale / unparseable.
+// GetStatus collapses missing / stale / unreadable / malformed into a single
+// ok=false so the caller can treat all four the same way (server offline).
 func (c WindroseClient) GetStatus() (WindroseStatus, bool) {
 	info, err := c.Stat(c.StatusPath)
 	if err != nil {

--- a/pkg/gameServers/client/windroseClient.go
+++ b/pkg/gameServers/client/windroseClient.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+// WindrosePlus has no usable A2S responder and no public HTTP endpoint, so the
+// API reads the dashboard's local status file directly. The file is owned by
+// user `windrose` but world-readable (mode 0644) — the API user just needs
+// filesystem access to /home/windrose/windrose/server-files/...
+//
+// Freshness gate matches windrose-metrics.sh: if the file hasn't been written
+// in MaxAge, the server is considered offline (container restarting, WP+
+// crashed, host hung).
+
+type WindroseStatus struct {
+	Server WindroseServerSection `json:"server"`
+}
+
+type WindroseServerSection struct {
+	Name        string `json:"name"`
+	PlayerCount int    `json:"player_count"`
+	MaxPlayers  int    `json:"max_players"`
+}
+
+type WindroseClient struct {
+	StatusPath string
+	MaxAge     time.Duration
+	Stat       func(string) (os.FileInfo, error)
+	Read       func(string) ([]byte, error)
+	Now        func() time.Time
+}
+
+func NewWindroseClient(statusPath string, maxAge time.Duration) WindroseClient {
+	return WindroseClient{
+		StatusPath: statusPath,
+		MaxAge:     maxAge,
+		Stat:       os.Stat,
+		Read:       os.ReadFile,
+		Now:        time.Now,
+	}
+}
+
+// GetStatus returns the parsed status when the file exists and is fresh.
+// A second return value of false means "treat as offline" — the caller does
+// not need to distinguish missing / stale / unparseable.
+func (c WindroseClient) GetStatus() (WindroseStatus, bool) {
+	info, err := c.Stat(c.StatusPath)
+	if err != nil {
+		return WindroseStatus{}, false
+	}
+	if c.Now().Sub(info.ModTime()) > c.MaxAge {
+		return WindroseStatus{}, false
+	}
+	data, err := c.Read(c.StatusPath)
+	if err != nil {
+		return WindroseStatus{}, false
+	}
+	var status WindroseStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return WindroseStatus{}, false
+	}
+	return status, true
+}

--- a/pkg/gameServers/client/windroseClient_test.go
+++ b/pkg/gameServers/client/windroseClient_test.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+type fakeFileInfo struct {
+	os.FileInfo
+	mtime time.Time
+}
+
+func (f fakeFileInfo) ModTime() time.Time { return f.mtime }
+
+func newClient(stat func(string) (os.FileInfo, error), read func(string) ([]byte, error), now time.Time) WindroseClient {
+	return WindroseClient{
+		StatusPath: "/fake/path",
+		MaxAge:     90 * time.Second,
+		Stat:       stat,
+		Read:       read,
+		Now:        func() time.Time { return now },
+	}
+}
+
+func TestGetStatus_Fresh(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	c := newClient(
+		func(string) (os.FileInfo, error) {
+			return fakeFileInfo{mtime: now.Add(-10 * time.Second)}, nil
+		},
+		func(string) ([]byte, error) {
+			return []byte(`{"server":{"name":"disqt.com","player_count":3,"max_players":10}}`), nil
+		},
+		now,
+	)
+
+	status, ok := c.GetStatus()
+	if !ok {
+		t.Fatal("expected ok=true for fresh file")
+	}
+	if status.Server.Name != "disqt.com" || status.Server.PlayerCount != 3 || status.Server.MaxPlayers != 10 {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
+func TestGetStatus_Stale(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	c := newClient(
+		func(string) (os.FileInfo, error) {
+			return fakeFileInfo{mtime: now.Add(-5 * time.Minute)}, nil
+		},
+		func(string) ([]byte, error) { return []byte(`{}`), nil },
+		now,
+	)
+
+	if _, ok := c.GetStatus(); ok {
+		t.Fatal("expected ok=false for stale file")
+	}
+}
+
+func TestGetStatus_Missing(t *testing.T) {
+	c := newClient(
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		func(string) ([]byte, error) { return nil, nil },
+		time.Now(),
+	)
+
+	if _, ok := c.GetStatus(); ok {
+		t.Fatal("expected ok=false when stat fails")
+	}
+}
+
+func TestGetStatus_ReadError(t *testing.T) {
+	now := time.Now()
+	c := newClient(
+		func(string) (os.FileInfo, error) { return fakeFileInfo{mtime: now}, nil },
+		func(string) ([]byte, error) { return nil, errors.New("read failed") },
+		now,
+	)
+
+	if _, ok := c.GetStatus(); ok {
+		t.Fatal("expected ok=false when read fails")
+	}
+}
+
+func TestGetStatus_Malformed(t *testing.T) {
+	now := time.Now()
+	c := newClient(
+		func(string) (os.FileInfo, error) { return fakeFileInfo{mtime: now}, nil },
+		func(string) ([]byte, error) { return []byte(`not json`), nil },
+		now,
+	)
+
+	if _, ok := c.GetStatus(); ok {
+		t.Fatal("expected ok=false for malformed JSON")
+	}
+}

--- a/pkg/gameServers/gameServerService.go
+++ b/pkg/gameServers/gameServerService.go
@@ -22,7 +22,10 @@ var serverLookups = [...]ServerLookup{
 	{Id: "csgo", Host: "disqt.com", Port: "27015"},
 }
 
-var windroseLookup = ServerLookup{Id: "windrose", Host: "disqt.com", Port: "7777"}
+// Windrose has no joinable URL to display: not a Steam Source game, no
+// one-click join scheme, players use the in-game invite-code flow. So host
+// and port are passed as empty, which makes the response Url field empty too.
+const windroseID = "windrose"
 
 // GetWindroseServer reads the WindrosePlus dashboard's local status file
 // rather than going through gamedig — Windrose isn't a supported gamedig type,
@@ -30,12 +33,12 @@ var windroseLookup = ServerLookup{Id: "windrose", Host: "disqt.com", Port: "7777
 func GetWindroseServer(windroseClient client.WindroseClient) model.GameServer {
 	status, ok := windroseClient.GetStatus()
 	if !ok {
-		return model.NewOfflineGameServer(windroseLookup.Id)
+		return model.NewOfflineGameServer(windroseID)
 	}
 	return model.NewOnlineGameServer(
-		windroseLookup.Id,
-		windroseLookup.Host,
-		windroseLookup.Port,
+		windroseID,
+		"",
+		"",
 		status.Server.PlayerCount,
 		status.Server.MaxPlayers,
 		status.Server.Name,

--- a/pkg/gameServers/gameServerService.go
+++ b/pkg/gameServers/gameServerService.go
@@ -22,6 +22,26 @@ var serverLookups = [...]ServerLookup{
 	{Id: "csgo", Host: "disqt.com", Port: "27015"},
 }
 
+var windroseLookup = ServerLookup{Id: "windrose", Host: "disqt.com", Port: "7777"}
+
+// GetWindroseServer reads the WindrosePlus dashboard's local status file
+// rather than going through gamedig — Windrose isn't a supported gamedig type,
+// and WP+ has no public query endpoint.
+func GetWindroseServer(windroseClient client.WindroseClient) model.GameServer {
+	status, ok := windroseClient.GetStatus()
+	if !ok {
+		return model.NewOfflineGameServer(windroseLookup.Id)
+	}
+	return model.NewOnlineGameServer(
+		windroseLookup.Id,
+		windroseLookup.Host,
+		windroseLookup.Port,
+		status.Server.PlayerCount,
+		status.Server.MaxPlayers,
+		status.Server.Name,
+	)
+}
+
 // GetGameServers queries all game servers concurrently via gamedig.
 // If a server query fails, it is reported as offline rather than crashing the API.
 func GetGameServers(gameDigClient client.GameDigClient) ([]model.GameServer, error) {

--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -41,11 +41,6 @@ func NewOnlineGameServer(name string, host string, port string, players int, max
 		redirect = "https://stats.xonotic.org/server/46827"
 	}
 
-	if strings.ToLower(name) == "windrose" {
-		host = ""
-		port = ""
-	}
-
 	if strings.ToLower(name) == "csgo" {
 		name = "Counter Strike 2"
 		redirect = "steam://rungameid/730//+connect " + host + ":27015"

--- a/pkg/gameServers/model/gameServer.go
+++ b/pkg/gameServers/model/gameServer.go
@@ -41,6 +41,11 @@ func NewOnlineGameServer(name string, host string, port string, players int, max
 		redirect = "https://stats.xonotic.org/server/46827"
 	}
 
+	if strings.ToLower(name) == "windrose" {
+		host = ""
+		port = ""
+	}
+
 	if strings.ToLower(name) == "csgo" {
 		name = "Counter Strike 2"
 		redirect = "steam://rungameid/730//+connect " + host + ":27015"


### PR DESCRIPTION
## Summary
- Adds Windrose to the `/servers` response so it shows up on disqt.com.
- gamedig has no Windrose protocol and WindrosePlus has no usable A2S responder, so query Windrose by reading the WP+ dashboard's local `server_status.json` file. Freshness gate (90s) matches `windrose-metrics.sh`.
- `Url` and `Redirect` are intentionally empty for Windrose — no joinable URL worth copying and no one-click join scheme; players use the in-game invite-code flow.

## Implementation notes
- New `client.WindroseClient` reads the status file with injectable `Stat`/`Read`/`Now` for tests.
- `ServerCache` now holds both clients; `cache.refresh()` appends `GetWindroseServer()` to the gamedig results before building the response.
- `NewOnlineGameServer` clears host+port for the `windrose` case so the response `Url` ends up empty.

## Deploy
After merge, on the VPS:
```bash
cd /home/dev/projects/lgsm-info-api
git pull
go build ./cmd/main.go
sudo systemctl restart lgsm-info-api.service
```
The service runs on `dev` and the WP+ status file is world-readable, so no permission changes are needed.

## Test plan
- [x] `go test ./...` passes
- [x] Existing `TestGetServersHandler` updated to include Windrose
- [x] New unit tests cover fresh / stale / missing / read-error / malformed paths
- [ ] After deploy, hit `https://disqt.com/servers` and verify Windrose entry with correct player count
- [ ] Verify Windrose row renders on `https://disqt.com/`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>